### PR TITLE
Fix prototypical_loss bug #23

### DIFF
--- a/src/prototypical_loss.py
+++ b/src/prototypical_loss.py
@@ -81,6 +81,6 @@ def prototypical_loss(input, target, n_support):
 
     loss_val = -log_p_y.gather(2, target_inds).squeeze().view(-1).mean()
     _, y_hat = log_p_y.max(2)
-    acc_val = y_hat.eq(target_inds.squeeze()).float().mean()
+    acc_val = y_hat.eq(target_inds.squeeze(2)).float().mean()
 
     return loss_val,  acc_val


### PR DESCRIPTION
`target_inds.shape == (n_classes, n_query, 1)`
`target_inds.squeeze().shape` is supposed to be `(n_classes, n_query)` but changes to `(n_classes, )` when n_query = 1 (one-shot) which leads to wrong acc_val.
Use `target_inds.squeeze(2)` instead of `target_inds.squeeze()` can fix it.